### PR TITLE
Fix typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,6 @@
 - **Adding a feature?** Awesome! Go ahead and fork, **create a new branch**, and push to your fork. After you've added your feature, open a pull request and we'll review ASAP!
 - **Reporting a security concern?** Do not open an issue here. Email hello@znci.dev with the subject "kelp: Security Concern - <brief description>"
 
-We also ask that all contributors follow znci's [code of confuct](https://github.com/znci/.github/blob/main/CODE_OF_CONDUCT.md).
+We also ask that all contributors follow znci's [code of conduct](https://github.com/znci/.github/blob/main/CODE_OF_CONDUCT.md).
 
 If you have found a user in violation of znci's code of conduct, please fill out this [form](https://forms.gle/xv38VhTuLKyrs9Lm9)


### PR DESCRIPTION
CONTRIBUTING.md referenced the znci "code of confuct". This PR changes that reference to "code of conduct".