### PR TITLE
Kelp 3.1.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ export default async function kelpify(app, options = {}) {
       consola.error(error);
     },
 
-    executeRouteMiddleware(checkpoint) {
+    registerMiddlewareAtCheckpoint(checkpoint) {
       this.options.middlewareCheckpoints[checkpoint]
         ? this.app.use(this.options.middlewareCheckpoints[checkpoint])
         : null;
@@ -339,12 +339,12 @@ export default async function kelpify(app, options = {}) {
     }).`
   );
 
-  this.executeRouteMiddleware("beforeRouteLoad");
+  this.registerMiddlewareAtCheckpoint("beforeRouteLoad");
 
   await kelp.loadRoutes();
 
-  this.executeRouteMiddleware("afterRouteLoad");
-  this.executeRouteMiddleware("beforeBuiltinMiddlewareRegister");
+  this.registerMiddlewareAtCheckpoint("afterRouteLoad");
+  this.registerMiddlewareAtCheckpoint("beforeBuiltinMiddlewareRegister");
 
   kelp.info("Loaded routes. Starting server...");
 
@@ -352,18 +352,18 @@ export default async function kelpify(app, options = {}) {
   kelp.app.use(express.urlencoded({ extended: true }));
   kelp.app.use(cookieParser());
 
-  this.executeRouteMiddleware("afterBuiltinMiddlewareRegister");
-  this.executeRouteMiddleware("before404Register");
+  this.registerMiddlewareAtCheckpoint("afterBuiltinMiddlewareRegister");
+  this.registerMiddlewareAtCheckpoint("before404Register");
 
   kelp.app.use(kelp.options.notFoundHandler);
 
-  this.executeRouteMiddleware("after404Register");
-  this.executeRouteMiddleware("beforeErrorRegister");
+  this.registerMiddlewareAtCheckpoint("after404Register");
+  this.registerMiddlewareAtCheckpoint("beforeErrorRegister");
 
   kelp.app.use(kelp.options.errorHandler);
 
-  this.executeRouteMiddleware("afterErrorRegister");
-  this.executeRouteMiddleware("beforeServe");
+  this.registerMiddlewareAtCheckpoint("afterErrorRegister");
+  this.registerMiddlewareAtCheckpoint("beforeServe");
 
   kelp.options.autostart
     ? kelp.start()

--- a/index.js
+++ b/index.js
@@ -78,8 +78,6 @@ export default async function kelpify(app, options = {}) {
           beforeServe: null,
           afterServe: null,
         },
-        corsEnabled: false,
-        corsOptions: {},
         port: 3000,
         environment: "development",
         autostart: true,
@@ -179,11 +177,6 @@ export default async function kelpify(app, options = {}) {
             );
             process.exit(1);
         }
-
-        if (this.options.corsEnabled) {
-          this.app.use(cors(this.options.corsOptions));
-        }
-
         for (const checkpoint in this.options.middlewareCheckpoints) {
           if (
             this.options.middlewareCheckpoints[checkpoint] !== null &&
@@ -339,12 +332,12 @@ export default async function kelpify(app, options = {}) {
     }).`
   );
 
-  this.registerMiddlewareAtCheckpoint("beforeRouteLoad");
+  kelp.registerMiddlewareAtCheckpoint("beforeRouteLoad");
 
   await kelp.loadRoutes();
 
-  this.registerMiddlewareAtCheckpoint("afterRouteLoad");
-  this.registerMiddlewareAtCheckpoint("beforeBuiltinMiddlewareRegister");
+  kelp.registerMiddlewareAtCheckpoint("afterRouteLoad");
+  kelp.registerMiddlewareAtCheckpoint("beforeBuiltinMiddlewareRegister");
 
   kelp.info("Loaded routes. Starting server...");
 
@@ -352,18 +345,18 @@ export default async function kelpify(app, options = {}) {
   kelp.app.use(express.urlencoded({ extended: true }));
   kelp.app.use(cookieParser());
 
-  this.registerMiddlewareAtCheckpoint("afterBuiltinMiddlewareRegister");
-  this.registerMiddlewareAtCheckpoint("before404Register");
+  kelp.registerMiddlewareAtCheckpoint("afterBuiltinMiddlewareRegister");
+  kelp.registerMiddlewareAtCheckpoint("before404Register");
 
   kelp.app.use(kelp.options.notFoundHandler);
 
-  this.registerMiddlewareAtCheckpoint("after404Register");
-  this.registerMiddlewareAtCheckpoint("beforeErrorRegister");
+  kelp.registerMiddlewareAtCheckpoint("after404Register");
+  kelp.registerMiddlewareAtCheckpoint("beforeErrorRegister");
 
   kelp.app.use(kelp.options.errorHandler);
 
-  this.registerMiddlewareAtCheckpoint("afterErrorRegister");
-  this.registerMiddlewareAtCheckpoint("beforeServe");
+  kelp.registerMiddlewareAtCheckpoint("afterErrorRegister");
+  kelp.registerMiddlewareAtCheckpoint("beforeServe");
 
   kelp.options.autostart
     ? kelp.start()

--- a/index.js
+++ b/index.js
@@ -98,8 +98,6 @@ export default async function kelpify(app, options = {}) {
         errorHandler: "function",
         methodNotAllowedHandler: "function",
         middlewareCheckpoints: "object",
-        corsEnabled: "boolean",
-        corsOptions: "object",
         port: "number",
         environment: "string",
         autostart: "boolean",
@@ -294,7 +292,7 @@ export default async function kelpify(app, options = {}) {
 
               this.options.environment === "development"
                 ? this.warn(
-                    `405: ${req.method} ${req.path} (expected ${method}))`
+                    `405: ${req.method} ${req.path} (expected ${method})`
                   )
                 : null;
             }

--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ import { consola } from "consola";
 import cookieParser from "cookie-parser";
 import express from "express";
 import fs from "node:fs";
+import cors from "cors";
 
 // view engines
 import nunjucks from "nunjucks";
@@ -56,6 +57,9 @@ export default async function kelpify(app, options = {}) {
           res.status(500).send("Internal server error");
           this.error(error);
         },
+        methodNotAllowedHandler: (req, res) => {},
+        corsEnabled: false,
+        corsOptions: {},
         port: 3000,
         environment: "development",
         autostart: true,
@@ -76,6 +80,9 @@ export default async function kelpify(app, options = {}) {
         viewEngine: "string",
         notFoundHandler: "function",
         errorHandler: "function",
+        methodNotAllowedHandler: "function",
+        corsEnabled: "boolean",
+        corsOptions: "object",
         port: "number",
         environment: "string",
         autostart: "boolean",
@@ -152,6 +159,10 @@ export default async function kelpify(app, options = {}) {
               )
             );
             process.exit(1);
+        }
+
+        if (this.options.corsEnabled) {
+          this.app.use(cors(this.options.corsOptions));
         }
       }
     },

--- a/index.js
+++ b/index.js
@@ -41,6 +41,12 @@ export default async function kelpify(app, options = {}) {
       consola.error(error);
     },
 
+    executeRouteMiddleware(checkpoint) {
+      this.options.middlewareCheckpoints[checkpoint]
+        ? this.app.use(this.options.middlewareCheckpoints[checkpoint])
+        : null;
+    },
+
     loadOptions() {
       const defaultOptions = {
         routesDirectory: __dirname + "/routes",
@@ -333,53 +339,31 @@ export default async function kelpify(app, options = {}) {
     }).`
   );
 
-  this.options.middlewareCheckpoints.beforeRouteLoad
-    ? this.options.middlewareCheckpoints.beforeRouteLoad()
-    : null;
+  this.executeRouteMiddleware("beforeRouteLoad");
 
   await kelp.loadRoutes();
 
-  this.options.middlewareCheckpoints.afterRouteLoad
-    ? this.options.middlewareCheckpoints.afterRouteLoad()
-    : null;
+  this.executeRouteMiddleware("afterRouteLoad");
+  this.executeRouteMiddleware("beforeBuiltinMiddlewareRegister");
 
   kelp.info("Loaded routes. Starting server...");
-
-  this.options.middlewareCheckpoints.beforeBuiltinMiddlewareRegister
-    ? this.options.middlewareCheckpoints.beforeBuiltinMiddlewareRegister()
-    : null;
 
   kelp.app.use(express.json());
   kelp.app.use(express.urlencoded({ extended: true }));
   kelp.app.use(cookieParser());
 
-  this.options.middlewareCheckpoints.afterBuiltinMiddlewareRegister
-    ? this.options.middlewareCheckpoints.afterBuiltinMiddlewareRegister()
-    : null;
-
-  this.options.middlewareCheckpoints.before404Register
-    ? this.options.middlewareCheckpoints.before404Register()
-    : null;
+  this.executeRouteMiddleware("afterBuiltinMiddlewareRegister");
+  this.executeRouteMiddleware("before404Register");
 
   kelp.app.use(kelp.options.notFoundHandler);
 
-  this.options.middlewareCheckpoints.after404Register
-    ? this.options.middlewareCheckpoints.after404Register()
-    : null;
-
-  this.options.middlewareCheckpoints.beforeErrorRegister
-    ? this.options.middlewareCheckpoints.beforeErrorRegister()
-    : null;
+  this.executeRouteMiddleware("after404Register");
+  this.executeRouteMiddleware("beforeErrorRegister");
 
   kelp.app.use(kelp.options.errorHandler);
 
-  this.options.middlewareCheckpoints.afterErrorRegister
-    ? this.options.middlewareCheckpoints.afterErrorRegister()
-    : null;
-
-  this.options.middlewareCheckpoints.beforeServe
-    ? this.options.middlewareCheckpoints.beforeServe()
-    : null;
+  this.executeRouteMiddleware("afterErrorRegister");
+  this.executeRouteMiddleware("beforeServe");
 
   kelp.options.autostart
     ? kelp.start()

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ import { consola } from "consola";
 import cookieParser from "cookie-parser";
 import express from "express";
 import fs from "node:fs";
-import cors from "cors";
 
 // view engines
 import nunjucks from "nunjucks";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,23 +1,22 @@
 {
-  "name": "kelp",
-  "version": "2.0.0-alpha",
+  "name": "@znci/kelp",
+  "version": "3.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "kelp",
-      "version": "2.0.0-alpha",
+      "name": "@znci/kelp",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3",
         "cookie-parser": "^1.4.6",
+        "cors": "^2.8.5",
         "ejs": "^3.1.9",
-        "esm-import-directory": "^2.4.1",
         "express": "^4.18.2",
         "express-handlebars": "^7.1.0",
         "nunjucks": "^3.2.4",
-        "pug": "^3.0.2",
-        "require-all": "^3.0.0"
+        "pug": "^3.0.2"
       }
     },
     "node_modules/@babel/helper-string-parser": {
@@ -157,23 +156,6 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
       "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ=="
-    },
-    "node_modules/async-compat": {
-      "version": "1.4.7",
-      "resolved": "https://registry.npmjs.org/async-compat/-/async-compat-1.4.7.tgz",
-      "integrity": "sha512-DzJRBBF6Q+AJYuAnFXflE5P0FEkJ7oKMOOR4YhzMNZsDnXOSUdCpYt+PpbCGrljempC3hujxy48rHBcBAWdr7g==",
-      "dependencies": {
-        "is-error": "^2.2.2",
-        "is-promise": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/async-compat/node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
     "node_modules/babel-walk": {
       "version": "3.0.0-canary-5",
@@ -364,6 +346,18 @@
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
     },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -449,28 +443,6 @@
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
       "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="
     },
-    "node_modules/esm-import-directory": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/esm-import-directory/-/esm-import-directory-2.4.1.tgz",
-      "integrity": "sha512-wKLNVjlT22c/unaiUYyUtF4oZftVOoRPV8WoeuSCmIBrEIxwWQWjU3QpPFfkLbYKrNn9GP0lwASsryz+Kdujxg==",
-      "dependencies": {
-        "esm-require-directory": "^2.7.3"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/esm-require-directory": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esm-require-directory/-/esm-require-directory-2.7.3.tgz",
-      "integrity": "sha512-qrjQiA/dDXN6fhdy31jE2gB6GLONgGcKviXCeNuUzj4iZYZUL3P8AGr8615Mft7RA0M6MnYZbRLU2kaU6jG8ew==",
-      "dependencies": {
-        "fs-iterator": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=0.12"
-      }
-    },
     "node_modules/etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
@@ -532,11 +504,6 @@
       "engines": {
         "node": ">=v16"
       }
-    },
-    "node_modules/fifo": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/fifo/-/fifo-2.4.1.tgz",
-      "integrity": "sha512-XTbUCNmo54Jav0hcL6VxDuY4x1eCQH61HEF80C2Oww283pfjQ2C8avZeyq4v43sW2S2403kmzssE9j4lbF66Sg=="
     },
     "node_modules/filelist": {
       "version": "1.0.4",
@@ -612,26 +579,6 @@
       "engines": {
         "node": ">= 0.6"
       }
-    },
-    "node_modules/fs-iterator": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/fs-iterator/-/fs-iterator-4.1.1.tgz",
-      "integrity": "sha512-OGs+RfryD8dOmMq5GgKhZxSNWqV9ktL/v2ZHzGW6h2/bWOzyqoiNv9QB6QfvTS0i+UGC+ASnhXmCUo0IX1qs9Q==",
-      "dependencies": {
-        "async-compat": "^1.4.6",
-        "fifo": "^2.4.1",
-        "fs.realpath": "^1.0.0",
-        "inherits": "^2.0.4",
-        "stack-base-iterator": "^0.1.7"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/fs.realpath": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "node_modules/function-bind": {
       "version": "1.1.1",
@@ -825,11 +772,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-error": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/is-error/-/is-error-2.2.2.tgz",
-      "integrity": "sha512-IOQqts/aHWbiisY5DuPJQ0gcbvaLFCa7fBa9xoLfxBZvQ+ZI/Zh9xoI7Gk+G64N0FdK4AbibytHht2tWgpJWLg=="
-    },
     "node_modules/is-expression": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-expression/-/is-expression-4.0.0.tgz",
@@ -871,22 +813,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
-    },
-    "node_modules/iterator-next-callback": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/iterator-next-callback/-/iterator-next-callback-1.1.4.tgz",
-      "integrity": "sha512-MZuFufT6WD9+wFuguBf0UeytnXQuYyfGx9nOFmHbV6NVQEXbZHuDb9h0vgBuPYHMBJKgDKvM1YBsl7rrj1pY7g==",
-      "dependencies": {
-        "is-promise": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/iterator-next-callback/node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ=="
     },
     "node_modules/jackspeak": {
       "version": "2.2.1",
@@ -936,30 +862,12 @@
         "promise": "^7.0.1"
       }
     },
-    "node_modules/just-extend": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
-      "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw=="
-    },
     "node_modules/lru-cache": {
       "version": "10.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.0.0.tgz",
       "integrity": "sha512-svTf/fzsKHffP42sujkO/Rjs37BCIsQVRCeNYIm9WN8rgT7ffoUnRtZCqU+6BqcSBdv8gwJeTz8knJpgACeQMw==",
       "engines": {
         "node": "14 || >=16.14"
-      }
-    },
-    "node_modules/maximize-iterator": {
-      "version": "2.6.6",
-      "resolved": "https://registry.npmjs.org/maximize-iterator/-/maximize-iterator-2.6.6.tgz",
-      "integrity": "sha512-VQ9dUjNy0Dgb81tCy5Ompkdx/edWvtS/D6XG4pQ050NWNduwtd3oB9swDTbCqOZ2Sj9xMjQK3/P4veR99N421Q==",
-      "dependencies": {
-        "async-compat": "^1.4.6",
-        "is-error": "^2.2.2",
-        "iterator-next-callback": "^1.1.2"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/media-typer": {
@@ -1107,14 +1015,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/once": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dependencies": {
-        "wrappy": "1"
       }
     },
     "node_modules/parseurl": {
@@ -1326,14 +1226,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/require-all": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/require-all/-/require-all-3.0.0.tgz",
-      "integrity": "sha512-jPGN876lc5exWYrMcgZSd7U42P0PmVQzxnQB13fCSzmyGnqQWW4WUz5DosZ/qe24hz+5o9lSvW2epBNZ1xa6Fw==",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/resolve": {
       "version": "1.22.2",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
@@ -1470,22 +1362,6 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/stack-base-iterator": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/stack-base-iterator/-/stack-base-iterator-0.1.7.tgz",
-      "integrity": "sha512-WxRdQrTzR3xOXFbzLuiVx12+xsmCbIvFsvIHUWvbY0096nc2qtFL0I9MjCzP03aVlnuSq+Svo3GOo4LLUS5xIA==",
-      "dependencies": {
-        "async-compat": "^1.4.6",
-        "fifo": "^2.4.1",
-        "inherits": "^2.0.4",
-        "just-extend": "^6.0.1",
-        "maximize-iterator": "^2.6.5",
-        "once": "^1.4.0"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/statuses": {
@@ -1796,11 +1672,6 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
-    },
-    "node_modules/wrappy": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,16 @@
 {
   "name": "@znci/kelp",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@znci/kelp",
-      "version": "3.0.1",
+      "version": "3.1.0",
       "license": "MIT",
       "dependencies": {
         "consola": "^3.2.3",
         "cookie-parser": "^1.4.6",
-        "cors": "^2.8.5",
         "ejs": "^3.1.9",
         "express": "^4.18.2",
         "express-handlebars": "^7.1.0",
@@ -345,18 +344,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ=="
-    },
-    "node_modules/cors": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   "dependencies": {
     "consola": "^3.2.3",
     "cookie-parser": "^1.4.6",
-    "cors": "^2.8.5",
     "ejs": "^3.1.9",
     "express": "^4.18.2",
     "express-handlebars": "^7.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@znci/kelp",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "An easy to use, customizable ExpressJS web server.",
   "main": "index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "consola": "^3.2.3",
     "cookie-parser": "^1.4.6",
+    "cors": "^2.8.5",
     "ejs": "^3.1.9",
     "express": "^4.18.2",
     "express-handlebars": "^7.1.0",


### PR DESCRIPTION
This PR is for version 3.1.0. It adds:
- Customizable 405 behavior
- Per-route middleware
- Custom middleware checkpoints (register middleware at a specific point in the kelp construction process)

The docs have **not** been updated to reflect these changes as newer docs are coming.